### PR TITLE
Return raw frame count from the simulator

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip wheel setuptools
         python -m pip install flake8
-        python -m pip install .
+        python -m pip install .[graph]
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -27,7 +27,13 @@ Graph representation
 
 .. important::
 
-    This module is experimental.
+    This module is experimental and requires ``jraph``.
+    Install it as:
+
+    .. code-block:: shell
+
+        pip install mapc-sim[graph]
+
 
 .. automodule:: mapc_sim.experimental.graph
     :members:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
 Sphinx~=7.2.6
--e .
+-e .[graph]

--- a/mapc_sim/sim.py
+++ b/mapc_sim/sim.py
@@ -9,7 +9,8 @@ from mapc_sim.utils import logsumexp_db, tgax_path_loss
 tfd = tfp.distributions
 
 
-def network_data_rate(key: PRNGKey, tx: Array, pos: Array, mcs: Array, tx_power: Array, sigma: Scalar, walls: Array) -> Scalar:
+def network_data_rate(key: PRNGKey, tx: Array, pos: Array, mcs: Array, tx_power: Array, sigma: Scalar,
+                      walls: Array, return_sample: bool = False) -> Scalar|tuple:
     r"""
     Calculates the aggregated effective data rate based on the nodes' positions, MCS, and tx power.
     Channel is modeled using TGax channel model with additive white Gaussian noise. Effective
@@ -40,11 +41,15 @@ def network_data_rate(key: PRNGKey, tx: Array, pos: Array, mcs: Array, tx_power:
         Standard deviation of the additive white Gaussian noise.
     walls: Array
         Adjacency matrix of walls. Each entry corresponds to a node.
+    return_sample: bool
+        A flag indicating whether the simulator returns raw number of
+        transmitted frames.
 
     Returns
     -------
-    Scalar
-        Aggregated effective data rate in Mb/s.
+    Scalar | tuple
+        Aggregated effective data rate in Mb/s if ``return_sample`` is ``False``.
+        Otherwise, a pair of data rate and the number of transmitted frames.
     """
 
     normal_key, binomial_key = jax.random.split(key)

--- a/mapc_sim/sim.py
+++ b/mapc_sim/sim.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 import jax
 import jax.numpy as jnp
 import tensorflow_probability.substrates.jax as tfp
@@ -10,7 +12,7 @@ tfd = tfp.distributions
 
 
 def network_data_rate(key: PRNGKey, tx: Array, pos: Array, mcs: Array, tx_power: Array, sigma: Scalar,
-                      walls: Array, return_sample: bool = False) -> Scalar|tuple:
+                      walls: Array, return_sample: bool = False) -> Union[Scalar,tuple]:
     r"""
     Calculates the aggregated effective data rate based on the nodes' positions, MCS, and tx power.
     Channel is modeled using TGax channel model with additive white Gaussian noise. Effective
@@ -77,4 +79,6 @@ def network_data_rate(key: PRNGKey, tx: Array, pos: Array, mcs: Array, tx_power:
     frames_transmitted = tfd.Binomial(total_count=n, logits=logit_success_prob).sample(seed=binomial_key)
 
     average_data_rate = FRAME_LEN * (frames_transmitted / TAU)
+    if return_sample:
+        return (average_data_rate.sum() / float(1e6), frames_transmitted)
     return average_data_rate.sum() / float(1e6)  # (Mbps)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mapc_sim"
-version = "0.1.2"
+version = "0.1.3"
 description = "IEEE 802.11 MAPC (c-SR) simulator"
 
 readme = "README.md"
@@ -20,7 +20,6 @@ dependencies = [
   "chex~=0.1.85",
   "jax~=0.4.23",
   "jaxlib~=0.4.23",
-  "jraph~=0.0.6.dev0",
   "matplotlib~=3.8.2",
   "tensorflow-probability[jax]~=0.23.0"
 ]
@@ -28,3 +27,6 @@ dependencies = [
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[project.optional-dependencies]
+graph = ["jraph~=0.0.6.dev0"]


### PR DESCRIPTION
- Add an option to obtain the number of frames successfully transmitted.
- Make the graph part optional.
- Bump version 